### PR TITLE
update compile for phar paths

### DIFF
--- a/src/Concerns/ParsesFilePath.php
+++ b/src/Concerns/ParsesFilePath.php
@@ -4,9 +4,13 @@ namespace Surgiie\Blade\Concerns;
 
 trait ParsesFilePath
 {
-    /**Parse a path name to filesystem path. */
+    /**
+     * Parse a path name to filesystem path for compile.
+     * This may be a component path as well.
+     */
     protected static function parseFilePath(string $path)
     {
+        // component paths via absolute path <x--*>
         if (str_starts_with($path, '-')) {
             $path = '/'.ltrim($path, '-');
         }


### PR DESCRIPTION
* Files in phar filesystems are not found correctly due to use of `realpath`. This PR adds code to better handle `phar` file paths and removes realpath usage when dealing with a phar path.
* Minor comments
